### PR TITLE
First try at allowing alternative hydrate and persist implementations

### DIFF
--- a/lib/hydrated.dart
+++ b/lib/hydrated.dart
@@ -87,7 +87,7 @@ class HydratedSubject<T> extends AbstractHydratedSubject<T>
   }
 
   @override
-  _persistValue(T val) async {
+  persistValue(T val) async {
     final prefs = await SharedPreferences.getInstance();
 
     if (val is int)
@@ -131,7 +131,7 @@ abstract class AbstractHydratedSubject<T> extends Subject<T>
   @override
   void onAdd(T event) {
     _wrapper.latestValue = event;
-    _persistValue(event);
+    persistValue(event);
   }
 
   @override
@@ -146,7 +146,7 @@ abstract class AbstractHydratedSubject<T> extends Subject<T>
 
   Future<void> hydrate();
 
-  _persistValue(T val);
+  persistValue(T val);
 
   /// A unique key that references a storage container for a value persisted on the device.
   String get key => this._key;

--- a/lib/hydrated.dart
+++ b/lib/hydrated.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:rxdart/rxdart.dart';
 
-/// A [BehaviorSubject] that automatically persists its values and is asynchrously hydrated.
+/// A [BehaviorSubject] that automatically persists its values and is asynchronously hydrated.
 ///
 /// Hydrate with the async method [HydratedSubject.hydrate()].
 ///
@@ -144,9 +144,6 @@ abstract class AbstractHydratedSubject<T> extends Subject<T>
   /// Set and emit the new value
   set value(T newValue) => add(newValue);
 
-  /// Hydrates the HydratedSubject with a value stored on the user's device.
-  ///
-  /// Must be called to retrieve values stored on the device.
   Future<void> hydrate();
 
   _persistValue(T val);


### PR DESCRIPTION
Now common code is in AbstractHydratedSubject.

When creating a custom HydratedSubject, you just need to override hydrate/_persistValue and implement the constructors. HydratedSetup also helps will some common code needed in the constructors.